### PR TITLE
bespokesynth: Fix Darwin support, use cmakeBuildType

### DIFF
--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -5,7 +5,6 @@
 , libxcb, xcbutil, libxkbcommon, xcbutilkeysyms, xcb-util-cursor
 , gtk3, webkitgtk, python3, curl, pcre, mount, gnome, patchelf
 , Cocoa, WebKit, CoreServices, CoreAudioKit
-, buildType ? "Release" # "Debug", or "Release"
 # It is not allowed to distribute binaries with the VST2 SDK plugin without a license
 # (the author of Bespoke has such a licence but not Nix). VST3 should work out of the box.
 # Read more in https://github.com/NixOS/nixpkgs/issues/145607
@@ -39,9 +38,9 @@ stdenv.mkDerivation rec {
     fetchSubmodules = true;
   };
 
-  cmakeFlags = [
-    "-DCMAKE_BUILD_TYPE=${buildType}"
-  ] ++ lib.optional enableVST2 "-DBESPOKE_VST2_SDK_LOCATION=${vst-sdk}/VST2_SDK";
+  cmakeBuildType = "Release";
+
+  cmakeFlags = lib.optionals enableVST2 [ "-DBESPOKE_VST2_SDK_LOCATION=${vst-sdk}/VST2_SDK" ];
 
   nativeBuildInputs = [ python3 makeWrapper cmake pkg-config ninja ];
 
@@ -84,7 +83,7 @@ stdenv.mkDerivation rec {
 
   postInstall = if stdenv.hostPlatform.isDarwin then ''
     mkdir -p $out/{Applications,bin}
-    mv Source/BespokeSynth_artefacts/${buildType}/BespokeSynth.app $out/Applications/
+    mv Source/BespokeSynth_artefacts/${cmakeBuildType}/BespokeSynth.app $out/Applications/
     # Symlinking confuses the resource finding about the actual location of the binary
     # Resources are looked up relative to the executed file's location
     makeWrapper $out/{Applications/BespokeSynth.app/Contents/MacOS,bin}/BespokeSynth

--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -4,6 +4,7 @@
 , libX11, libXrandr, libXinerama, libXext, libXcursor, libGL
 , libxcb, xcbutil, libxkbcommon, xcbutilkeysyms, xcb-util-cursor
 , gtk3, webkitgtk, python3, curl, pcre, mount, gnome, patchelf
+, Cocoa, WebKit, CoreServices, CoreAudioKit
 , buildType ? "Release" # "Debug", or "Release"
 # It is not allowed to distribute binaries with the VST2 SDK plugin without a license
 # (the author of Bespoke has such a licence but not Nix). VST3 should work out of the box.
@@ -44,8 +45,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [ python3 makeWrapper cmake pkg-config ninja ];
 
-  # List obtained in https://github.com/BespokeSynth/BespokeSynth/blob/main/azure-pipelines.yml
-  buildInputs = [
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    # List obtained in https://github.com/BespokeSynth/BespokeSynth/blob/main/azure-pipelines.yml
     libX11
     libXrandr
     libXinerama
@@ -69,12 +70,28 @@ stdenv.mkDerivation rec {
     pcre
     mount
     patchelf
+  ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    Cocoa
+    WebKit
+    CoreServices
+    CoreAudioKit
   ];
 
-  # Ensure zenity is available, or it won't be able to open new files.
-  # Ensure the python used for compilation is the same as the python used at run-time.
-  # jedi is also required for auto-completion.
-  postInstall = ''
+  NIX_CFLAGS_COMPILE = lib.optionalString stdenv.hostPlatform.isDarwin (toString [
+    # Fails to find fp.h on its own
+    "-isystem ${CoreServices}/Library/Frameworks/CoreServices.framework/Versions/Current/Frameworks/CarbonCore.framework/Versions/Current/Headers/"
+  ]);
+
+  postInstall = if stdenv.hostPlatform.isDarwin then ''
+    mkdir -p $out/{Applications,bin}
+    mv Source/BespokeSynth_artefacts/${buildType}/BespokeSynth.app $out/Applications/
+    # Symlinking confuses the resource finding about the actual location of the binary
+    # Resources are looked up relative to the executed file's location
+    makeWrapper $out/{Applications/BespokeSynth.app/Contents/MacOS,bin}/BespokeSynth
+  '' else ''
+    # Ensure zenity is available, or it won't be able to open new files.
+    # Ensure the python used for compilation is the same as the python used at run-time.
+    # jedi is also required for auto-completion.
     wrapProgram $out/bin/BespokeSynth --prefix PATH : '${
       lib.makeBinPath [
         gnome.zenity

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -24013,9 +24013,11 @@ with pkgs;
 
   berry = callPackage ../applications/window-managers/berry { };
 
-  bespokesynth = callPackage ../applications/audio/bespokesynth { };
+  bespokesynth = callPackage ../applications/audio/bespokesynth {
+    inherit (darwin.apple_sdk.frameworks) Cocoa WebKit CoreServices CoreAudioKit;
+  };
 
-  bespokesynth-with-vst2 = callPackage ../applications/audio/bespokesynth {
+  bespokesynth-with-vst2 = bespokesynth.override {
     enableVST2 = true;
   };
 


### PR DESCRIPTION
###### Motivation for this change
https://github.com/NixOS/nixpkgs/pull/144708#discussion_r763110982

###### Things done

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [x] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
