### PR TITLE
bespokesynth: Fix missing libs

### DIFF
--- a/pkgs/applications/audio/bespokesynth/default.nix
+++ b/pkgs/applications/audio/bespokesynth/default.nix
@@ -1,7 +1,7 @@
 { lib, stdenv, fetchFromGitHub, fetchzip
 , cmake, pkg-config, ninja, makeWrapper
 , libjack2, alsa-lib, alsa-tools, freetype, libusb1
-, libX11, libXrandr, libXinerama, libXext, libXcursor, libGL
+, libX11, libXrandr, libXinerama, libXext, libXcursor, libXScrnSaver, libGL
 , libxcb, xcbutil, libxkbcommon, xcbutilkeysyms, xcb-util-cursor
 , gtk3, webkitgtk, python3, curl, pcre, mount, gnome, patchelf
 , Cocoa, WebKit, CoreServices, CoreAudioKit
@@ -51,6 +51,7 @@ stdenv.mkDerivation rec {
     libXinerama
     libXext
     libXcursor
+    libXScrnSaver
     curl
     gtk3
     webkitgtk
@@ -91,12 +92,18 @@ stdenv.mkDerivation rec {
     # Ensure zenity is available, or it won't be able to open new files.
     # Ensure the python used for compilation is the same as the python used at run-time.
     # jedi is also required for auto-completion.
-    wrapProgram $out/bin/BespokeSynth --prefix PATH : '${
-      lib.makeBinPath [
+    # These X11 libs get dlopen'd, they cause visual bugs when unavailable.
+    wrapProgram $out/bin/BespokeSynth \
+      --prefix PATH : '${lib.makeBinPath [
         gnome.zenity
         (python3.withPackages (ps: with ps; [ jedi ]))
-      ]
-    }'
+      ]}' \
+      --prefix LD_LIBRARY_PATH : '${lib.makeLibraryPath [
+        libXrandr
+        libXinerama
+        libXcursor
+        libXScrnSaver
+      ]}'
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change
These libraries are loaded at runtime via `dlopen`. When unavailable they don't cause the application to fail, but produce other visual bugs instead: https://github.com/BespokeSynth/BespokeSynth/issues/680

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [x] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [x] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nix-review --run "nix-review wip"`
- [x] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
- [ ] Assured whether relevant documentation is up to date
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---
